### PR TITLE
fix: Custom labels variable name

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -19,7 +19,7 @@ labels:
   password:  Password
   login:  Log on
   logout: Log off
-  alreadyloggedin:  You are already logged on.
+  message_alreadyloggedin:  You are already logged on.
   message_default:  Please provide your username and password to gain access.
   message_correct:  Thank you for providing the correct password. You now have access to the protected pages.
   message_wrong:  The password was not correct. Try again.


### PR DESCRIPTION
fix the label-name in default config file to match [src/Twig/PasswordProtect.php#L89](https://github.com/bobdenotter/PasswordProtect/blob/738c3fd353205dd147543c7504a4889d068b41c1/src/Twig/PasswordProtect.php#L89)